### PR TITLE
Fix  issue #166

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1189,7 +1189,7 @@ var // currently active contextMenu trigger
                 .on('mousedown', handle.layerClick);
             
             // IE6 doesn't know position:fixed;
-            if (!$.support.fixedPosition) {
+            if (document.body.style.maxWidth === undefined) {//IE6 doesn't support maxWidth
                 $layer.css({
                     'position' : 'absolute',
                     'height' : $(document).height()


### PR DESCRIPTION
This fix is for #166 
`$.support.fixedPosition` is also `true`  in IE8 despite of it's support of position fix.
So I changed if-statement for judging IE6. 
(`$.browser` is removed from jQuery 1.9 above. I think it's most simple sentence to judge IE6)