### PR TITLE
BlurItem: removed root

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -776,8 +776,7 @@ var // currently active contextMenu trigger
             e.stopPropagation();
             var $this = $(this),
                 data = $this.data(),
-                opt = data.contextMenu,
-                root = data.contextMenuRoot;
+                opt = data.contextMenu;
             
             $this.removeClass('hover');
             opt.$selected = null;


### PR DESCRIPTION
Variable `root` defined but never used in `blurItem` method.