### PR TITLE
contextMenu always visible in window

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -134,6 +134,10 @@ var // currently active contextMenu trigger
             if (offset.top + height > bottom) {
                 offset.top -= height;
             }
+
+            if (offset.top<0) {
+                offset.top = 0;
+            }
             
             if (offset.left + width > right) {
                 offset.left -= width;


### PR DESCRIPTION
When i will show the contextMenu that height+position of click is greater than window height a part of the contextmenu is hidden because it will show the contextMenu above the position of click.
Example
![contextmenu](https://cloud.githubusercontent.com/assets/3445672/2801032/d86a4698-cc7c-11e3-89b5-86af9ee9b013.png)
