### PR TITLE
Update jquery.contextMenu.js for Uncaught TypeError: Illegal invocation in Chrome

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -247,7 +247,7 @@ var // currently active contextMenu trigger
                     if (!e.data.items || $.isEmptyObject(e.data.items)) {
                         // Note: jQuery captures and ignores errors from event handlers
                         if (window.console) {
-                            (console.error || console.log)("No items specified to show in contextMenu");
+                            (console.error || console.log).apply(console, ["No items specified to show in contextMenu"]);
                         }
                         
                         throw new Error('No Items specified');


### PR DESCRIPTION
(console.error || console.log)("No items specified to show in contextMenu");

Creates an error in Chrome : Uncaught TypeError: Illegal invocation       jquery.contextMenu.js:250