### PR TITLE
Fixed an uncaught error in contextMenu()

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1222,7 +1222,7 @@ $.fn.contextMenu = function(operation) {
     } else if (operation.x && operation.y) {
         this.first().trigger($.Event("contextmenu", {pageX: operation.x, pageY: operation.y}));
     } else if (operation === "hide") {
-        var $menu = this.data('contextMenu').$menu;
+        var $menu = this.first().data('contextMenu') ? this.first().data('contextMenu').$menu : null;
         $menu && $menu.trigger('contextmenu:hide');
     } else if (operation === "destroy") {
         $.contextMenu("destroy", {context: this});


### PR DESCRIPTION
 Fixed an uncaught error in contextMenu when data('contextMenu') is undefined (for example when .contextMenu() is used on an element without an initialized contextMenu). 
Also added a "first()" method call to better match the documentation which says that .contextMenu("hide") should "hide the contextMenu of the first element of the selector". 